### PR TITLE
Migrated to .NET Standard 2.0, which is still in preview.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_script:
 script:
   - dotnet restore
   - dotnet build --configuration ${BUILD_CONFIG}
-  - dotnet test --configuration ${BUILD_CONFIG} --no-build
+  - dotnet test --configuration ${BUILD_CONFIG} --no-build Didstopia.FeatherJSON.Tests
   - dotnet pack --configuration ${BUILD_CONFIG} --no-build
 
 # Additional jobs that run after tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,11 +23,24 @@ env:
 - BUILD_CONFIG="Debug" DOTNET_CLI_TELEMETRY_OPTOUT=1
 - BUILD_CONFIG="Release" DOTNET_CLI_TELEMETRY_OPTOUT=1
 
+## NOTE: See the following url for the versions of the .NET Core SDK, runtime etc.
+##       https://github.com/dotnet/core/blob/master/release-notes/download-archives/2.0.0-preview2-download.md
+
+# Install dependencies
+install:
+  - bash <(curl -s https://raw.githubusercontent.com/dotnet/cli/master/scripts/obtain/dotnet-install.sh) --channel "LTS" --version "latest"
+  - bash <(curl -s https://raw.githubusercontent.com/dotnet/cli/master/scripts/obtain/dotnet-install.sh) --channel "2.0" --version "2.0.0-preview2-006497"
+  - bash <(curl -s https://raw.githubusercontent.com/dotnet/cli/master/scripts/obtain/dotnet-install.sh) --channel "2.0" --version "latest"
+
+# Setup for the build script
+before_script:
+  - export PATH=$HOME/.dotnet:$PATH
+
 # Build script
 script:
   - dotnet restore
   - dotnet build --configuration ${BUILD_CONFIG}
-  - dotnet test --configuration ${BUILD_CONFIG} Didstopia.FeatherJSON.Tests/Didstopia.FeatherJSON.Tests.csproj
+  - dotnet test --configuration ${BUILD_CONFIG} --no-build
   - dotnet pack --configuration ${BUILD_CONFIG} --no-build
 
 # Additional jobs that run after tests

--- a/Didstopia.FeatherJSON.Extensions/Didstopia.FeatherJSON.Extensions.csproj
+++ b/Didstopia.FeatherJSON.Extensions/Didstopia.FeatherJSON.Extensions.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.6</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <NETStandardImplicitPackageVersion>2.0.0-preview2-25401-01</NETStandardImplicitPackageVersion>
     <VersionPrefix>0.0.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Authors>Didstopia</Authors>
@@ -13,11 +14,15 @@
     <PackageProjectUrl>https://github.com/Didstopia/FeatherJSON</PackageProjectUrl>
     <PackageReleaseNotes>Initial release.</PackageReleaseNotes>
     <Summary>Extensions for Didstopia.FeatherJSON.</Summary>
-    <PackageTags>.net dotnet standard library json extension compression csharp c# xamarin watchos ios android uwp windows phone wp</PackageTags>
+    <PackageTags>.net dotnet standard 2.0 library json extension compression csharp c# xamarin watchos ios android uwp windows phone wp</PackageTags>
     <Title>Didstopia.FeatherJSON.Extensions</Title>
     <Description>Extensions for Didstopia.FeatherJSON.</Description>
+    <ReleaseVersion>0.0.1</ReleaseVersion>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType></DebugType>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Didstopia.FeatherJSON\Didstopia.FeatherJSON.csproj" />
   </ItemGroup>

--- a/Didstopia.FeatherJSON.Tests/Didstopia.FeatherJSON.Tests.csproj
+++ b/Didstopia.FeatherJSON.Tests/Didstopia.FeatherJSON.Tests.csproj
@@ -1,9 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <RuntimeFrameworkVersion>2.0.0-preview2-25407-01</RuntimeFrameworkVersion>
     <IsPackable>false</IsPackable>
+    <VersionPrefix>0.0.1</VersionPrefix>
+    <VersionSuffix></VersionSuffix>
     <ReleaseVersion>0.0.1</ReleaseVersion>
   </PropertyGroup>
 

--- a/Didstopia.FeatherJSON/Didstopia.FeatherJSON.csproj
+++ b/Didstopia.FeatherJSON/Didstopia.FeatherJSON.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.6</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <NETStandardImplicitPackageVersion>2.0.0-preview2-25401-01</NETStandardImplicitPackageVersion>
     <Description>FeatherJSON is a lightweight ("light as a feather") JSON library for C#.</Description>
     <VersionPrefix>0.0.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
@@ -14,16 +15,13 @@
     <PackageProjectUrl>https://github.com/Didstopia/FeatherJSON</PackageProjectUrl>
     <PackageReleaseNotes>Initial release.</PackageReleaseNotes>
     <Summary>FeatherJSON is a lightweight ("light as a feather") JSON library for C#.</Summary>
-    <PackageTags>.net dotnet standard library json csharp c# xamarin watchos ios android uwp windows phone wp</PackageTags>
+    <PackageTags>.net dotnet standard 2.0 library json csharp c# xamarin watchos ios android uwp windows phone wp</PackageTags>
     <Title>Didstopia.FeatherJSON</Title>
+    <ReleaseVersion>0.0.1</ReleaseVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType></DebugType>
     <Optimize>true</Optimize>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
-    <PackageReference Include="System.Runtime.Serialization.Json" Version="4.3.0" />
-  </ItemGroup>
 </Project>

--- a/Didstopia.FeatherJSON/LinkerSafe.cs
+++ b/Didstopia.FeatherJSON/LinkerSafe.cs
@@ -23,5 +23,6 @@
 using System;
 using Didstopia.FeatherJSON;
 
+// TODO: Not sure if this actually works/does anything?
 [assembly:LinkerSafe]
 namespace Didstopia.FeatherJSON { class LinkerSafeAttribute : Attribute { } }

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,10 +1,10 @@
-# Apache 2.0 License  
+# Apache 2.0 License
 
-Copyright (c) 2017 Didstopia  
+Copyright (c) 2017 Didstopia
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
-You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0  
+You may obtain a copy of the License at [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Status](https://travis-ci.org/Didstopia/FeatherJSON.svg?branch=master)](https://
 
 FeatherJSON is a lightweight ("light as a feather") JSON library for C#.
 
-# License
+**NOTE:** FeatherJSON is a .NET Standard 2.0 library, which is still in preview. Additionally note that FeatherJSON is a _work in progress_.
+
+## License
 
 See [LICENSE.md](LICENSE.md).


### PR DESCRIPTION
This allowed us to reference regular .NET system libraries, which should drastically bring the size of this library down, as we're no longer including System libraries as DLLs.