### PR TITLE
Better type support, serialization improvements and unit test fixes

### DIFF
--- a/Didstopia.FeatherJSON.Extensions/Didstopia.FeatherJSON.Extensions.csproj
+++ b/Didstopia.FeatherJSON.Extensions/Didstopia.FeatherJSON.Extensions.csproj
@@ -17,7 +17,7 @@
     <PackageTags>.net dotnet standard 2.0 library json extension compression csharp c# xamarin watchos ios android uwp windows phone wp</PackageTags>
     <Title>Didstopia.FeatherJSON.Extensions</Title>
     <Description>Extensions for Didstopia.FeatherJSON.</Description>
-    <ReleaseVersion>0.0.1</ReleaseVersion>
+    <ReleaseVersion>0.1.0</ReleaseVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">

--- a/Didstopia.FeatherJSON/Didstopia.FeatherJSON.csproj
+++ b/Didstopia.FeatherJSON/Didstopia.FeatherJSON.csproj
@@ -17,7 +17,7 @@
     <Summary>FeatherJSON is a lightweight ("light as a feather") JSON library for C#.</Summary>
     <PackageTags>.net dotnet standard 2.0 library json csharp c# xamarin watchos ios android uwp windows phone wp</PackageTags>
     <Title>Didstopia.FeatherJSON</Title>
-    <ReleaseVersion>0.0.1</ReleaseVersion>
+    <ReleaseVersion>0.1.0</ReleaseVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">

--- a/Didstopia.FeatherJSON/JSONObject.cs
+++ b/Didstopia.FeatherJSON/JSONObject.cs
@@ -27,6 +27,10 @@ using System.Globalization;
 using System.Reflection;
 using System.Text;
 using Didstopia.FeatherJSON.Parser;
+using System.Linq;
+using System.Collections.ObjectModel;
+using System.Linq.Expressions;
+using System.Diagnostics;
 
 namespace Didstopia.FeatherJSON
 {
@@ -58,25 +62,52 @@ namespace Didstopia.FeatherJSON
             var typeProperties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
             foreach (var typeProperty in typeProperties)
             {
+                var propertyType = typeProperty.PropertyType;
+                var propertyArguments = typeProperty.PropertyType.GetGenericArguments();
+
+                // Check for JSONSerializerIgnoreAttribute
+                if (Attribute.IsDefined(typeProperty, typeof(JSONSerializerIgnore)))
+                {
+                    Debug.WriteLine($"GetProperties -> Type {propertyType} marked as ignored, skipping");
+                    continue;
+                }
+
                 var propertyValue = typeProperty.GetValue(o);
+
+                Console.Write("\n");
+                Debug.WriteLine($"GetProperties -> Getting type {propertyType} with value: {propertyValue}");
+
+                if (propertyValue == null)
+                {
+                    Debug.WriteLine($"GetProperties -> Type {propertyType} value was null, skipping");
+                    result.Add(typeProperty.Name, null);
+                    continue;
+                }
+
+                // FIXME: Switch to a switch, like in SetProperties
+                // FIXME: Refactor both GetProperties and SetProperties to use reusable methods,
+                //        instead of cramming everything inside these two methods
 
                 // TODO: If it's a list, it doesn't have a key/name, so it needs to be an array!
 
                 // Handle value types ands primitives
                 if (propertyValue.GetType().IsValueType || propertyValue.GetType().IsPrimitive)
                 {
+                    Debug.WriteLine($"GetProperties -> Type is value type or primitive: {propertyType}");
                     result.Add(typeProperty.Name, propertyValue);
                 }
 
                 // Handle decimals
                 else if (propertyValue is Decimal)
                 {
+                    Debug.WriteLine($"GetProperties -> Type is decimal: {propertyType}");
                     result.Add(typeProperty.Name, propertyValue);
                 }
 
                 // Handle strings
                 else if (propertyValue is string)
                 {
+                    Debug.WriteLine($"GetProperties -> Type is string: {propertyType}");
                     result.Add(typeProperty.Name, propertyValue);
                 }
 
@@ -84,32 +115,35 @@ namespace Didstopia.FeatherJSON
                 // Handle primitive arrays
                 else if (propertyValue is byte[])
                 {
+                    Debug.WriteLine($"GetProperties -> Type is byte[]: {propertyType}");
                     result.Add(typeProperty.Name, propertyValue);
                 }
 
                 // Handle dictionaries
                 else if (propertyValue as IDictionary != null)
                 {
+                    Debug.WriteLine($"GetProperties -> Type is IDictionary: {propertyType}");
                     var dictionary = propertyValue as IDictionary;
                     Dictionary<string, object> dictionaryResult = new Dictionary<string, object>();
-                    foreach (KeyValuePair<string, object> item in dictionary)
+                    foreach (DictionaryEntry item in dictionary)
                     {
                         if (item.Value.GetType().IsValueType)
                         {
-                            dictionaryResult.Add(item.Key, item.Value);
+                            dictionaryResult.Add(item.Key.ToString(), item.Value);
                         }
                         else
                         {
                             var itemProperties = GetProperties(item.Value.GetType(), item.Value);
-                            dictionaryResult.Add(item.Key, itemProperties);
+                            dictionaryResult.Add(item.Key.ToString(), itemProperties);
                         }
                     }
                     result.Add(typeProperty.Name, dictionaryResult);
                 }
 
-                // Handle lists
+                // Handle lists (also handles collections)
                 else if (propertyValue as IList != null)
                 {
+                    Debug.WriteLine($"GetProperties -> Type is IList: {propertyType}");
                     var list = propertyValue as IList;
                     List<object> listResult = new List<object>();
                     foreach (var element in list)
@@ -129,8 +163,7 @@ namespace Didstopia.FeatherJSON
 
                 else
                 {
-                    Console.WriteLine("Unhandled type: " + type);
-
+                    Debug.WriteLine($"GetProperties -> Unhandled type: {type}");
                     result.Add(typeProperty.Name, GetProperties(propertyValue.GetType(), propertyValue));
                 }
             }
@@ -144,31 +177,193 @@ namespace Didstopia.FeatherJSON
             var typeProperties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
             foreach (var typeProperty in typeProperties)
             {
+                var propertyType = typeProperty.PropertyType;
+                var propertyArguments = typeProperty.PropertyType.GetGenericArguments();
+
+                // Check for JSONSerializerIgnoreAttribute
+                if (Attribute.IsDefined(typeProperty, typeof(JSONSerializerIgnore)))
+                {
+                    Debug.WriteLine($"SetProperties -> Type {propertyType} marked as ignored, skipping");
+                    continue;
+                }
+
                 var propertyValue = properties[typeProperty.Name];
 
-                // TODO: Handle stuff like we do in GetProperties
+                Debug.WriteLine("\n");
+                Debug.WriteLine($"SetProperties -> Setting type {propertyType} with value: {propertyValue}");
 
-                // TODO: None of these support nullable properties (ie. Nullable<DateTimeOffset> or DateTimeOffset?)
+                if (propertyValue == null)
+                {
+                    // TODO: Skip null values if the serializer option is set
+                    Debug.WriteLine($"SetProperties -> Type {propertyType} value was null, skipping");
+                    typeProperty.SetValue(result, null);
+                    continue;
+                }
 
-                // TODO: How do we do this for child objects?
-                //typeProperty.SetValue(result, SetProperties(typeProperty.GetType(), null));
+                // Handle different types accordingly
+                switch (propertyType)
+                {
+                    // TODO: Refactor to it's own IsX() method
+                    // DateTime and DateTime?
+                    case Type dateTimeType when (dateTimeType == typeof(DateTime) || dateTimeType == typeof(DateTime?)):
+                        Debug.WriteLine($"SetProperties -> Type is DateTime(?): {propertyType}");
+                        typeProperty.SetValue(result, DateTime.ParseExact(propertyValue.ToString(), "o", CultureInfo.InvariantCulture));
+                        break;
 
-                // HACK: Just trying to see if this works out of the box like this
-                if (typeProperty.PropertyType.Equals(typeof(DateTime)) || typeProperty.PropertyType.Equals(typeof(DateTime?)))
-                    typeProperty.SetValue(result, DateTime.ParseExact(propertyValue.ToString(), "o", CultureInfo.InvariantCulture));
-                else if (typeProperty.PropertyType.Equals(typeof(DateTimeOffset)) || typeProperty.PropertyType.Equals(typeof(DateTimeOffset?)))
-                    typeProperty.SetValue(result, DateTimeOffset.ParseExact(propertyValue.ToString(), "o", CultureInfo.InvariantCulture));
-                else if (typeProperty.PropertyType.Equals(typeof(byte[])))
-                    typeProperty.SetValue(result, Convert.FromBase64String(propertyValue.ToString()));
-                else if (typeProperty.PropertyType.IsValueType)
-                    typeProperty.SetValue(result, propertyValue);
-                else if (typeProperty.PropertyType.IsClass && propertyValue is Dictionary<string, object>)
-                    typeProperty.SetValue(result, SetProperties(typeProperty.PropertyType, (Dictionary<string, object>)propertyValue));
-                else
-                    typeProperty.SetValue(result, propertyValue);
+                    // TODO: Refactor to it's own IsX() method
+                    // DateTimeOffset and DateTimeOffset?
+                    case Type dateTimeOffsetType when (dateTimeOffsetType == typeof(DateTimeOffset) || dateTimeOffsetType == typeof(DateTimeOffset?)):
+                        Debug.WriteLine($"SetProperties -> Type is DateTimeOffset(?): {propertyType}");
+                        typeProperty.SetValue(result, DateTimeOffset.ParseExact(propertyValue.ToString(), "o", CultureInfo.InvariantCulture));
+                        break;
 
-                // FIXME: Object of type 'System.Collections.Generic.Dictionary`2[System.String,System.Object]'
-                //        cannot be converted to type 'Core.Abstractions.DummyChildModel'
+                    // TODO: Refactor to it's own IsX() method
+                    // byte[]
+                    case Type byteArrayType when byteArrayType == typeof(byte[]):
+                        Debug.WriteLine($"SetProperties -> Type is byte[]: {propertyType}");
+                        typeProperty.SetValue(result, Convert.FromBase64String(propertyValue.ToString()));
+                        break;
+
+                    // TODO: Refactor to it's own IsX() method
+                    // string
+                    case Type stringType when stringType == typeof(string):
+                        Debug.WriteLine($"SetProperties -> Type is string: {propertyType}");
+                        typeProperty.SetValue(result, propertyValue);
+                        break;
+
+                    // TODO: Refactor to it's own IsX() method
+                    // Primitive type
+                    case Type primitiveType when primitiveType.IsPrimitive:
+                        Debug.WriteLine($"SetProperties -> Type is primitive: {propertyType}");
+                        typeProperty.SetValue(result, propertyValue);
+                        break;
+
+                    // TODO: Refactor to it's own IsX() method
+                    // Value type
+                    case Type valueType when valueType.IsValueType:
+                        Debug.WriteLine($"SetProperties -> Type is value type: {propertyType}");
+                        typeProperty.SetValue(result, propertyValue);
+                        break;
+
+                    // TODO: Refactor to it's own IsX() method
+                    // Custom object type
+                    case Type objectType when (objectType.IsClass && !objectType.Namespace.StartsWith("System.", StringComparison.InvariantCulture) && propertyValue is Dictionary<string, object>):
+                        Debug.WriteLine($"SetProperties -> Type is custom object: {propertyType}");
+                        typeProperty.SetValue(result, SetProperties(propertyType, (Dictionary<string, object>)propertyValue));
+                        break;
+
+                    // Dictionary type
+                    case Type dictionaryType when IsDictionary(dictionaryType):
+                        Debug.WriteLine($"SetProperties -> Type is dictionary: {propertyType}");
+
+                        // Create a dictionary of the correct target type
+                        Type targetDictionaryType = typeof(Dictionary<,>).MakeGenericType(propertyArguments);
+                        IDictionary targetDictionary = (IDictionary)Activator.CreateInstance(targetDictionaryType);
+
+                        var targetDictionaryKeyType = propertyArguments[0];
+                        var targetDictionaryValueType = propertyArguments[1];
+
+                        foreach (DictionaryEntry i in (IDictionary)propertyValue)
+                        {
+                            var sourceKeyType = i.Key.GetType();
+                            var sourceValueType = i.Value.GetType();
+
+                            // Check if i.Value is a Dictionary<string, object>
+                            if (i.Value is Dictionary<string, object>)
+                            {
+                                // Create a new instance of the target value from the provided properties
+                                var targetValue = SetProperties(targetDictionaryValueType, i.Value as Dictionary<string, object>);
+
+                                // Add the instance to the targetDictionary
+                                targetDictionary.Add(i.Key, targetValue);
+                            }
+
+                            // Otherwise just assign the values as they are
+                            else
+                            {
+                                targetDictionary.Add(i.Key, i.Value);
+                            }
+                        }
+
+                        typeProperty.SetValue(result, targetDictionary);
+
+                        break;
+
+                    // TODO: Combine List and Collection code, since they're
+                    //       essentially the same thing, right?
+
+                    // List type
+                    case Type listType when IsList(listType):
+                        Debug.WriteLine($"SetProperties -> Type is list: {propertyType}");
+
+                        // Create a list of the correct target type
+                        Type targetListType = typeof(List<>).MakeGenericType(propertyArguments);
+                        IList targetList = (IList)Activator.CreateInstance(targetListType);
+
+                        var targetListValueType = propertyArguments[0];
+
+                        // Loop through list
+                        foreach (var item in (IList)propertyValue)
+                        {
+                            // Check if item is a Dictionary<string, object>
+                            if (item is Dictionary<string, object>)
+                            {
+                                // Create a new instance of the target item from the provided properties
+                                var targetItem = SetProperties(targetListValueType, item as Dictionary<string, object>);
+
+                                // Add the instance to the targetList
+                                targetList.Add(targetItem);
+                            }
+
+                            // Otherwise just assign the values as they are
+                            else
+                            {
+                                targetList.Add(item);
+                            }
+                        }
+
+                        typeProperty.SetValue(result, targetList);
+
+                        break;
+
+                    // Collection type
+                    case Type collectionType when IsCollection(collectionType):
+                        Debug.WriteLine($"SetProperties -> Type is collection: {propertyType}");
+
+                        // Create a list of the correct target type
+                        Type targetCollectionType = typeof(Collection<>).MakeGenericType(propertyArguments);
+                        IList targetCollection = (IList)Activator.CreateInstance(targetCollectionType);
+
+                        var targetCollectionValueType = propertyArguments[0];
+
+                        // Loop through collection
+                        foreach (var item in (IList)propertyValue)
+                        {
+                            // Check if item is a Dictionary<string, object>
+                            if (item is Dictionary<string, object>)
+                            {
+                                // Create a new instance of the target item from the provided properties
+                                var targetItem = SetProperties(targetCollectionValueType, item as Dictionary<string, object>);
+
+                                // Add the instance to the targetCollection
+                                targetCollection.Add(targetItem);
+                            }
+
+                            // Otherwise just assign the values as they are
+                            else
+                            {
+                                targetCollection.Add(item);
+                            }
+                        }
+
+                        typeProperty.SetValue(result, targetCollection);
+
+                        break;
+
+                    case Type defaultType:
+                        Debug.WriteLine($"SetProperties -> ERROR: Invalid or unsupported type: {propertyType}");
+                        throw new NotSupportedException($"Invalid or unsupported type: {propertyType}.");
+                }
             }
             return result;
         }
@@ -202,6 +397,49 @@ namespace Didstopia.FeatherJSON
                 return Object.ToString();
             
             return JSONParser.JsonEncode(Properties);
+        }
+
+        /*public static object Cast(Type Type, object data)
+        {
+            var DataParam = Expression.Parameter(typeof(object), "data");
+            var Body = Expression.Block(Expression.Convert(Expression.Convert(DataParam, data.GetType()), Type));
+
+            var Run = Expression.Lambda(Body, DataParam).Compile();
+            var ret = Run.DynamicInvoke(data);
+            return ret;
+        }*/
+
+        private static bool IsDictionary(Type type)
+        {
+            return /*type is IDictionary &&*/
+                   type.IsGenericType &&
+                   type.GetGenericTypeDefinition().IsAssignableFrom(typeof(Dictionary<,>));
+            /*if (o == null) return false;
+            return o is IDictionary ||
+                   (o.GetType().IsGenericType &&
+                   o.GetType().GetGenericTypeDefinition().IsAssignableFrom(typeof(Dictionary<,>)));*/
+        }
+
+        private static bool IsList(Type type)
+        {
+            return /*type is IList &&*/
+                   type.IsGenericType &&
+                   type.GetGenericTypeDefinition().IsAssignableFrom(typeof(IList<>));
+            /*if (o == null) return false;
+            return o is IList ||
+                   (o.GetType().IsGenericType &&
+                   o.GetType().GetGenericTypeDefinition().IsAssignableFrom(typeof(List<>)));*/
+        }
+
+        private static bool IsCollection(Type type)
+        {
+            return /*type is ICollection &&*/
+                   type.IsGenericType &&
+                   type.GetGenericTypeDefinition().IsAssignableFrom(typeof(ICollection<>));
+            /*if (o == null) return false;
+            return o is ICollection ||
+                   (o.GetType().IsGenericType &&
+                   o.GetType().GetGenericTypeDefinition().IsAssignableFrom(typeof(Collection<>)));*/
         }
     }
 }

--- a/Didstopia.FeatherJSON/JSONSerializer.cs
+++ b/Didstopia.FeatherJSON/JSONSerializer.cs
@@ -26,6 +26,11 @@ using System.Text;
 
 namespace Didstopia.FeatherJSON
 {
+    public sealed class JSONSerializerIgnore : Attribute
+    {
+        // TODO: Do we need to implement anything here?
+    }
+
     public sealed class JSONSerializer
     {
         public Type Type { get; }

--- a/FeatherJSON.sln
+++ b/FeatherJSON.sln
@@ -27,7 +27,7 @@ Global
 		{78B2414F-C747-495B-933E-796916BFCB77}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
-		version = 0.0.1
+		version = 0.1.0
 		Policies = $0
 		$0.StandardHeader = $1
 		$1.Text = @${FileName}\n\nCopyright (c) ${Year} ${CopyrightHolder}\n\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the "Software"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in\nall copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN\nTHE SOFTWARE.

--- a/UnitTests/Core/Abstractions/DummyModel.cs
+++ b/UnitTests/Core/Abstractions/DummyModel.cs
@@ -21,7 +21,8 @@
 // THE SOFTWARE.
 
 using System;
-
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using Didstopia.FeatherJSON;
 
 namespace Core.Abstractions
@@ -29,29 +30,36 @@ namespace Core.Abstractions
     public class DummyModel : IDisposable
     {
         // TODO: Add dummy properties of all possible types (primitives, lists etc.)
+        // TODO: Make sure and document that only public properties can be serialized (but not fields)
+        // TODO: Add a custom attribute for ignoring serialization values
 
-        // NOTE: These are all included in the serialization by default
+        // NOTE: These are all included in the serialization by default,
+        //       apart from those marked with [JSONSerializerIgnore]
         public string StringProperty { get; set; }
         public DateTimeOffset? DateTimeOffsetProperty { get; set; }
         public byte[] ByteArrayProperty { get; set; }
         public bool BoolProperty { get; set; }
+        [JSONSerializerIgnore] public bool IgnoredBoolProperty { get; set; }
         public DummyChildModel ChildProperty { get; set; }
+        public IList<DummyChildModel> ChildListProperty { get; set; }
+        public ICollection<DummyChildModel> ChildCollectionProperty { get; set; }
+        public Dictionary<string, DummyChildModel> ChildDictionaryProperty { get; set; }
 
-        // NOTE: These are all included in the serialization by default
+        // NOTE: Public fields should not be serialized
         public string StringField;
         public DateTimeOffset? DateTimeOffsetField;
         public byte[] ByteArrayField;
-        [SerializerIgnore] public bool BoolField;
-        [SerializerIgnore] DummyChildModel ChildField;
+        public bool BoolField;
+        DummyChildModel ChildField;
 
-        // NOTE: These are all NOT included in the serialization by default
+        // NOTE: Private properties should not be serialized
         string PrivateStringProperty { get; set; }
         DateTimeOffset? PrivateDateTimeOffsetProperty { get; set; }
         byte[] PrivateByteArrayProperty { get; set; }
         bool PrivateBoolProperty { get; set; }
         DummyChildModel PrivateChildProperty { get; set; }
 
-        // NOTE: These are all NOT included in the serialization by default
+        // NOTE: Private fields should not be serialized
         string PrivateStringField;
         DateTimeOffset? PrivateDateTimeOffsetField;
         byte[] PrivateByteArrayField;
@@ -66,11 +74,18 @@ namespace Core.Abstractions
             BoolProperty = default(bool);
             ChildProperty?.Dispose();
             ChildProperty = null;
+            ChildListProperty?.Clear();
+            ChildListProperty = null;
+            ChildCollectionProperty?.Clear();
+            ChildCollectionProperty = null;
+            ChildDictionaryProperty?.Clear();
+            ChildDictionaryProperty = null;
 
             StringField = default(string);
             DateTimeOffsetField = default(DateTimeOffset);
             ByteArrayField = default(byte[]);
             BoolField = default(bool);
+            IgnoredBoolProperty = default(bool);
             ChildField?.Dispose();
             ChildField = null;
 
@@ -97,7 +112,11 @@ namespace Core.Abstractions
                 DateTimeOffsetProperty = DateTimeOffset.UtcNow,
                 ByteArrayProperty = Guid.NewGuid().ToByteArray(),
                 BoolProperty = true,
+                IgnoredBoolProperty = true,
                 ChildProperty = DummyChildModel.Create(),
+                ChildListProperty = new List<DummyChildModel> { DummyChildModel.Create() },
+                ChildCollectionProperty = new Collection<DummyChildModel> { DummyChildModel.Create() },
+                ChildDictionaryProperty = new Dictionary<string, DummyChildModel> { { "Child", DummyChildModel.Create() } },
 
                 StringField = Guid.NewGuid().ToString(),
                 DateTimeOffsetField = DateTimeOffset.UtcNow,

--- a/UnitTests/Core/Parser/JSONParserTests.cs
+++ b/UnitTests/Core/Parser/JSONParserTests.cs
@@ -28,6 +28,9 @@ using Utilities;
 
 using Didstopia.FeatherJSON;
 using Didstopia.FeatherJSON.Parser;
+using System.Collections.Generic;
+using System.Collections;
+using System.Diagnostics;
 
 namespace Core
 {
@@ -48,15 +51,56 @@ namespace Core
         [Fact]
         public void Should_ParseObjectValue()
         {
-            Logger.WriteLine("Should_ParseObjectValue()");
-
-            // TODO: Test everything, including DummyModel and it's children
+            // Test serialization
             var serializedModel = Converter.SerializeObject(Model);
-            Console.WriteLine("Serialized model: " + serializedModel);
-            Assert.NotNull(serializedModel);
+            Logger.WriteLine("Serialized JSON: " + serializedModel);
+            AssertNotNullOrEmpty(serializedModel, "Serialized JSON string cannot be null or empty");
 
-            var deserializerModel = Converter.DeserializeObject<DummyModel>(serializedModel);
-            Assert.NotNull(deserializerModel);
+            // Test deserialization
+            var deserializedModel = Converter.DeserializeObject<DummyModel>(serializedModel);
+            Assert.NotNull(deserializedModel);
+
+            // Test deserialized public properties
+            AssertNotNullOrEmpty(deserializedModel.StringProperty, "StringProperty cannot be null or empty");
+            AssertNotNullOrEmpty(deserializedModel.DateTimeOffsetProperty, "DateTimeOffsetProperty cannot be null");
+            AssertNotNullOrEmpty(deserializedModel.ByteArrayProperty, "ByteArrayProperty cannot be null or empty");
+            Assert.True(deserializedModel.BoolProperty, "BoolProperty cannot be false");
+            Assert.False(deserializedModel.IgnoredBoolProperty, "IgnoredBoolProperty cannot be true");
+            AssertNotNullOrEmpty(deserializedModel.ChildProperty, "ChildProperty cannot be null");
+            AssertNotNullOrEmpty(deserializedModel.ChildListProperty, "ChildListProperty cannot be null or empty");
+            AssertNotNullOrEmpty(deserializedModel.ChildCollectionProperty, "ChildCollectionProperty cannot be null or empty");
+            AssertNotNullOrEmpty(deserializedModel.ChildDictionaryProperty, "ChildDictionaryProperty cannot be null or empty");
+
+            // TODO: Test deserialized public fields
+
+
+            // TODO: Test deserialized private properties
+
+
+            // TODO: Test deserialized private fields
+
+        }
+
+        private static void AssertNotNullOrEmpty(object o, string message = null)
+        {
+            var result = true;
+
+            if (o == null)
+                result = false;
+
+            else if (o is string)
+                result = ((string)o).Length > 0;
+
+            else if (o is IList)
+                result = ((IList)o).Count > 0;
+
+            else if (o is ICollection)
+                result = ((ICollection)o).Count > 0;
+
+            else if (o is IDictionary)
+                result = ((IDictionary)o).Count > 0;
+
+            Assert.True(result, message);
         }
     }
 }

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -6,7 +6,7 @@
     <IsPackable>false</IsPackable>
     <VersionPrefix>0.0.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
-    <ReleaseVersion>0.0.1</ReleaseVersion>
+    <ReleaseVersion>0.1.0</ReleaseVersion>
     <Description>Unit tests for Didstopia.FeatherJSON and Didstopia.FeatherJSON.Extensions.</Description>
   </PropertyGroup>
 


### PR DESCRIPTION
- Added support for Dictionary, List and Collection
- Added proper recursive support
- Added proper custom class support
- Added [JSONSerializerIgnore] attribute for ignoring serialization
- Made sure only public properties are serialized
- Fixed unit tests

Still missing at least generic array support, and only supports byte arrays for now.
Serializer options are also not used at the moment, and will mainly provide JSON pretty printing, as well as the
ability to skip/ignore null values when serializing to JSON.